### PR TITLE
Add Tabs and Image preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Use with caution.
 {{< /admonition >}}
 ```
 
+## Tabs
+
+Tabbed-view navigation is supported using the following shortcode.
+
+```
+{{< tabs "uniqueid" >}}
+{{< tab "tab 1 title" >}} 
+  tab 1 Content 
+{{< /tab >}}
+{{< tab "tab 2 title" >}} 
+  tab 2 Content 
+{{< /tab >}}
+...
+{{< /tabs >}}
+```
+
+Pleaste note that the `uniqueid` must be unique for each tab group.
+
 ## Frontmatter
 
 We use YAML-formatted [front matter](https://gohugo.io/content-management/front-matter/).

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -116,6 +116,10 @@ module.exports = {
 							marginTop: "0",
 							marginBottom: "0",
 						},
+						img: {
+							borderRadius: "0.1875rem",
+							cursor: "pointer",
+						},
 					},
 				},
 			},

--- a/themes/minio-hugo-docs/assets/js/imagePreview.js
+++ b/themes/minio-hugo-docs/assets/js/imagePreview.js
@@ -1,0 +1,53 @@
+import { iconSprite } from "./utils";
+
+export const imagePreview = () => {
+	const IMG_ELS = document.querySelectorAll(".prose p img");
+	const BODY = document.body;
+
+	// Create a wrapper element to hold the image and close icon
+	const WRAPPER = document.createElement("div");
+	WRAPPER.setAttribute(
+		"class",
+		"fixed inset-0 z-50 bg-black/75 p-5 pt-12 flex items-center cursor-pointer opacity-0 transition-opacity duration-500 outline-none"
+	);
+	WRAPPER.setAttribute("tabindex", "0");
+	WRAPPER.onclick = () => {
+		hidePreview();
+	};
+	WRAPPER.addEventListener("keydown", (e) => {
+		if (e.key === "Escape") {
+			hidePreview();
+		}
+	});
+
+	// Create a close icon
+	const CLOSE_ICON = `<i class="fixed top-3 right-3 w-8 h-8 grid place-content-center rounded-full bg-white/20 hover:bg-white/30 text-white">
+                            ${iconSprite("close", 10, 10)}
+                        </i>`;
+
+	// Show the image preview
+	const showPreview = (src) => {
+		BODY.appendChild(WRAPPER);
+		WRAPPER.focus();
+		WRAPPER.innerHTML = `<img src="${src}" class="rounded max-h-full m-auto" /> ${CLOSE_ICON}`;
+
+		setTimeout(() => WRAPPER.classList.add("opacity-100"));
+	};
+
+	// Hide the image preview
+	const hidePreview = () => {
+		WRAPPER.classList.remove("opacity-100");
+		setTimeout(() => {
+			BODY.removeChild(WRAPPER);
+		}, 500);
+	};
+
+	// Add click event listener to each image
+	if (IMG_ELS.length > 0) {
+		IMG_ELS.forEach((img) => {
+			img.addEventListener("click", () => {
+				showPreview(img.src);
+			});
+		});
+	}
+};

--- a/themes/minio-hugo-docs/assets/js/index.js
+++ b/themes/minio-hugo-docs/assets/js/index.js
@@ -1,4 +1,5 @@
 import { header } from "./header";
+import { imagePreview } from "./imagePreview";
 import { siteSearch } from "./search";
 import { sidebar } from "./sidebar";
 import { toc } from "./toc";
@@ -14,3 +15,6 @@ sidebar();
 
 // TOC
 toc();
+
+// Image preview
+imagePreview();

--- a/themes/minio-hugo-docs/layouts/shortcodes/tab.html
+++ b/themes/minio-hugo-docs/layouts/shortcodes/tab.html
@@ -1,0 +1,8 @@
+{{- $name := .Get 0 }}
+{{- $group := printf "tabs-%s" (.Parent.Get 0) }}
+
+{{- if not (.Parent.Scratch.Get $group) }}
+	{{- .Parent.Scratch.Set $group slice }}
+{{- end }}
+
+{{- .Parent.Scratch.Add $group (dict "Name" $name "Content" .Inner) }}

--- a/themes/minio-hugo-docs/layouts/shortcodes/tabs.html
+++ b/themes/minio-hugo-docs/layouts/shortcodes/tabs.html
@@ -1,0 +1,23 @@
+{{- $id := .Get 0 }}
+{{- $group := printf "tabs-%s" $id }}
+<div class="my-5 flex flex-wrap">
+	{{- range $index, $tab := .Scratch.Get $group }}
+		<input
+			type="radio"
+			class="hidden [&:checked+*+*]:block [&:checked+*]:border-theme-red [&:checked+*]:text-heading dark:[&:checked+*]:border-dark-500"
+			name="{{ $group }}"
+			id="{{ printf "%s-%d" $group $index }}"
+			{{ if not $index }}checked="checked"{{ end }}
+		/>
+		<label
+			for="{{ printf "%s-%d" $group $index }}"
+			class="relative mr-7 inline-block cursor-pointer border-b-2 border-transparent py-3 font-medium leading-none text-muted hover:text-heading"
+		>
+			{{ $tab.Name }}
+		</label>
+		<div class="order-[99] -mt-px hidden w-full border-t border-light-400 pt-3 dark:border-dark-200">
+			{{ .Content | $.Page.RenderString }}
+			{{ .Inner }}
+		</div>
+	{{- end }}
+</div>


### PR DESCRIPTION
Fixes  https://github.com/minio/kes-docs/issues/10

Image preview works out of the box on all content images. For tabs, add the following shortcode:

```
{{< tabs "uniqueid" >}}
{{< tab "tab 1 title" >}} 
  tab 1 Content 
{{< /tab >}}
{{< tab "tab 2 title" >}} 
  tab 2 Content 
{{< /tab >}}
...
{{< /tabs >}}
```

Pleaste note that the `uniqueid` must be unique for each tab group.
