### PR TITLE
Improvements for inline code

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,9 +52,6 @@ module.exports = {
 			fontSize: {
 				md: "0.9375rem",
 			},
-			backgroundColor: {
-				header: "var(--header-bg)",
-			},
 			textColor: {
 				body: "var(--text-color)",
 				muted: "var(--text-muted-color)",
@@ -112,6 +109,14 @@ module.exports = {
 							fontWeight: "700",
 							borderRadius: "0.1875rem",
 							padding: "1rem 1.25rem",
+						},
+						code: {
+							backgroundColor: "var(--pre-bg)",
+							color: "var(--text-color)",
+							padding: "0.125rem 0.25rem",
+							borderRadius: "0.1875rem",
+							borderWidth: "1px",
+							borderColor: "transparent",
 						},
 						"code::before": {
 							content: '""',

--- a/themes/minio-hugo-docs/assets/css/_theme.scss
+++ b/themes/minio-hugo-docs/assets/css/_theme.scss
@@ -11,7 +11,7 @@ $theme-properties: (
 	--scrollbar-bg: #dedede $dark-300,
 	--scrollbar-hover-bg: #c6c6c6 lighten($dark-300, 5%),
 	// Typography
-	--pre-bg: $light-300 $dark-200
+	--pre-bg: $light-200 $dark-200
 );
 
 // Activate dark/light themes

--- a/themes/minio-hugo-docs/layouts/partials/head/meta.html
+++ b/themes/minio-hugo-docs/layouts/partials/head/meta.html
@@ -1,14 +1,13 @@
 <meta charset="UTF-8" />
 <meta name="referrer" content="no-referrer" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<meta name="color-scheme" content="light dark" />
 {{ hugo.Generator }}
 
 {{ $keywords := default .Site.Params.Keywords .Keywords }}
 
 {{- with partial "utils/description" . }}
-	<meta name="description" content="{{ trim (. | plainify) "\n" | safeHTML }}" />
+<meta name="description" content="{{ trim (. | plainify) " \n" | safeHTML }}" />
 {{- end }}
 {{- with $keywords }}
-	<meta name="keywords" content="{{ delimit . "," }}" />
+<meta name="keywords" content="{{ delimit . " ," }}" />
 {{- end }}

--- a/themes/minio-hugo-docs/layouts/partials/toc.html
+++ b/themes/minio-hugo-docs/layouts/partials/toc.html
@@ -1,50 +1,40 @@
 <aside
 	class="{{ if not .Page.Params.TableOfContents }}
 		lg:hidden
-	{{ end }} sticky top-0 z-[1] order-2 flex flex-shrink-0 items-center gap-3 bg-white p-5 dark:bg-dark-0 lg:w-60 lg:px-0"
->
-	<button
-		type="button"
-		id="sidebar-open"
-		class="grid h-10 w-10 flex-shrink-0 place-content-center rounded border border-light-300 text-muted hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:hidden"
-	>
+	{{ end }} sticky top-0 z-[1] order-2 flex flex-shrink-0 items-center gap-3 bg-white p-5 dark:bg-dark-0 lg:w-60 lg:px-0">
+	<button type="button" id="sidebar-open"
+		class="grid h-10 w-10 flex-shrink-0 place-content-center rounded border border-light-300 text-muted hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:hidden">
 		<svg class="h-3.5 w-3.5 text-heading">
 			<use xlink:href="/img/svg-sprite.svg#menu"></use>
 		</svg>
 	</button>
 
 	{{ if .Page.Params.TableOfContents }}
-		<div class="relative z-[2] flex-1" id="toc">
-			<div
-				id="toc-toggle"
-				class="relative z-[2] flex h-10 cursor-pointer select-none items-center rounded border border-light-300 px-4 text-sm font-bold text-heading hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:-mb-2 lg:cursor-default lg:border-none lg:bg-transparent lg:text-md lg:hover:!bg-transparent [&.active]:rounded-bl-none [&.active]:rounded-br-none"
-			>
-				Table of Contents
+	<div class="relative z-[2] flex-1" id="toc">
+		<div id="toc-toggle"
+			class="relative z-[2] flex h-10 cursor-pointer select-none items-center rounded border border-light-300 px-4 text-sm font-bold text-heading hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:-mb-2 lg:cursor-default lg:border-none lg:bg-transparent lg:text-md lg:hover:!bg-transparent [&.active]:rounded-bl-none [&.active]:rounded-br-none">
+			Table of Contents
 
-				<svg class="ml-auto mt-px h-2.5 w-2.5 transition-transform duration-200 lg:hidden">
-					<use xlink:href="/img/svg-sprite.svg#chevron-down"></use>
-				</svg>
-			</div>
+			<svg class="ml-auto mt-px h-2.5 w-2.5 transition-transform duration-200 lg:hidden">
+				<use xlink:href="/img/svg-sprite.svg#chevron-down"></use>
+			</svg>
+		</div>
+		<div id="toc-dropdown"
+			class="absolute left-0 top-full z-[1] hidden w-full rounded-bl rounded-br border border-t-0 border-light-300 bg-light-300/50 text-sm backdrop-blur-md dark:border-dark-300 dark:bg-dark-0/75 lg:relative lg:block lg:border-none lg:bg-transparent [&.active]:block">
 			<div
-				id="toc-dropdown"
-				class="absolute left-0 top-full z-[1] hidden w-full rounded-bl rounded-br border border-t-0 border-light-300 bg-light-300/50 text-sm backdrop-blur-md dark:border-dark-300 dark:bg-dark-0/75 lg:relative lg:block lg:border-none lg:bg-transparent [&.active]:block"
-			>
-				<div
-					class="scrollbar h-full max-h-44 overflow-auto py-2 px-4 lg:max-h-full lg:pl-8 [&_a:hover]:text-body [&_a]:block [&_a]:py-0.5 [&_a]:text-muted [&_ul_ul]:ml-3"
-				>
-					<i class="absolute left-0.5 top-0 bottom-0 my-3.5 ml-4 hidden w-[2px] rounded bg-light-200 dark:bg-dark-200 lg:block"></i>
+				class="scrollbar h-full max-h-44 overflow-auto py-2 px-4 lg:max-h-full lg:pl-8 [&_a:hover]:text-body [&_a]:block [&_a]:py-0.5 [&_a]:text-muted [&_ul_ul]:ml-3 [&_code]:font-bold">
+				<i
+					class="absolute left-0.5 top-0 bottom-0 my-3.5 ml-4 hidden w-[2px] rounded bg-light-200 dark:bg-dark-200 lg:block "></i>
 
-					{{ .TableOfContents }}
-				</div>
+				{{ .TableOfContents }}
 			</div>
 		</div>
+	</div>
 	{{ end }}
 
 
-	<button
-		type="button"
-		class="search-toggle ml-auto grid h-10 w-10 flex-shrink-0 place-content-center rounded border border-light-300 text-muted hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:hidden"
-	>
+	<button type="button"
+		class="search-toggle ml-auto grid h-10 w-10 flex-shrink-0 place-content-center rounded border border-light-300 text-muted hover:bg-light-100/75 dark:border-dark-300 dark:hover:bg-dark-100 lg:hidden">
 		<svg class="h-3.5 w-3.5 text-heading">
 			<use xlink:href="/img/svg-sprite.svg#search"></use>
 		</svg>

--- a/themes/minio-hugo-docs/layouts/shortcodes/admonition.html
+++ b/themes/minio-hugo-docs/layouts/shortcodes/admonition.html
@@ -2,23 +2,27 @@
 {{ $classList := default "note" }}
 
 {{ if eq (.Get "type") "note" }}
-	{{ $classList = "text-[#1467c2] dark:text-blue-500 border-blue-500/20 bg-blue-500/10 [&_pre]:border-blue-500/20" }}
+{{ $classList = `text-[#1467c2] dark:text-blue-500 border-blue-500/20 bg-blue-500/10 [&_pre]:border-blue-500/20
+[&_code]:border-blue-500/20` }}
 {{ else if eq (.Get "type") "tip" }}
-	{{ $classList = "text-green-600 border-green-500/20 bg-green-500/5 [&_pre]:border-green-500/20" }}
+{{ $classList = `text-green-600 border-green-500/20 bg-green-500/5 [&_pre]:border-green-500/20
+[&_code]:border-green-500/20` }}
 {{ else if eq (.Get "type") "caution" }}
-	{{ $classList = "text-amber-600 border-amber-500/20 bg-amber-500/5 [&_pre]:border-amber-500/20" }}
+{{ $classList = `text-amber-600 border-amber-500/20 bg-amber-500/5 [&_pre]:border-amber-500/20
+[&_code]:border-amber-500/20` }}
 {{ else if eq (.Get "type") "warning" }}
-	{{ $classList = "text-red-500 dark:text-red-500/80 border-red-500/20 bg-red-500/5 [&_pre]:border-red-500/20" }}
+{{ $classList = `text-red-500 dark:text-red-500/80 border-red-500/20 bg-red-500/5 [&_pre]:border-red-500/20
+[&_code]:border-red-500/20` }}
 {{ end }}
 
 
 <div
-	class="admonition {{ $classList }} my-5 rounded border px-5 py-4 text-md leading-normal [&_a]:text-current [&_p]:mb-0 [&_p]:mt-2 [&_pre]:border [&_pre]:bg-white [&_pre]:dark:bg-dark-0"
->
+	class="admonition {{ $classList }} my-5 rounded border px-5 py-4 text-md leading-normal [&_a]:text-current [&_p]:m-0 [&_p+p]:mt-2 [&_pre]:border [&_pre]:bg-white [&_pre]:dark:bg-dark-0">
 	{{ if $title }}
-		<div class="mb-2 text-md font-bold">{{ $title }}:</div>
+	<div class="mb-2 text-md font-bold">{{ $title }}:</div>
 	{{ end }}
-	<div class="text-md [&_a]:underline [&_a]:decoration-1 [&_a]:underline-offset-4 [&_a]:hover:text-current [&_li]:marker:text-current [&_pre]:mb-0">
+	<div
+		class="text-md [&_a]:underline [&_a]:decoration-1 [&_a]:underline-offset-4 [&_a]:hover:text-current [&_li]:marker:text-current [&_pre]:mb-0 [&_*:not(pre)_code]:bg-white [&_*:not(pre)_code]:dark:bg-dark-0">
 		{{ .Inner | $.Page.RenderString }}
 	</div>
 </div>


### PR DESCRIPTION
Updated the inline code styles on both content level and admonition. 

<img width="640" alt="Screenshot 2023-03-08 at 14 18 18" src="https://user-images.githubusercontent.com/13393018/223687466-84f2b5a9-6b02-4380-bfe7-764d5a23f432.png">
<img width="290" alt="Screenshot 2023-03-08 at 14 18 44" src="https://user-images.githubusercontent.com/13393018/223687472-b3b8f1bd-9f78-40c5-9fc8-1103c11ed9e8.png">
