### PR TITLE
Add build-docs script and fix build error

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+export NVM_DIR="${HOME}/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+nvm use stable
+
+export PATH=${PATH}:${HOME}/.local/bin
+
+git submodule update --init --recursive
+git submodule update --recursive --remote
+
+hugo
+
+sudo rm -rf /var/www/docs/kes/
+sudo mkdir -p /var/www/docs/kes/
+sudo cp -vr public/* /var/www/docs/kes/

--- a/content/cli/kes-enclave/create.md
+++ b/content/cli/kes-enclave/create.md
@@ -31,7 +31,7 @@ A short, human-readable name to use to interact with the enclave with the KES co
 
 _Required_
 
-The [`subject`]({{< relref "cli/kes-enclave/new.md#subject" >}}) of the identity to use to create the enclave.
+The [`subject`]({{< relref "cli/kes-identity/new.md#subject" >}}) of the identity to use to create the enclave.
 
 ### `--insecure, -k`
 


### PR DESCRIPTION
As the title says.
Adds a script for building the docs so we can automate that.
Also fixes a link causing an error during build.