### PR TITLE
Updates for April and May 2023 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The KES docs use [Hugo](https://www.gohogo.io) to generate static HTML pages.
     - [Markup](#markup)
     - [Style Guides](#style-guides)
     - [Spelling](#spelling)
+    - [Code Blocks](#code-blocks)
   - [Shortcodes](#shortcodes)
     - [Internal linking](#internal-linking)
     - [Components (Tabs, Admonitions, Cards, etc.)](#components-tabs-admonitions-cards-etc)
@@ -101,6 +102,22 @@ Otherwise, follow these resources in order of preference:
 ### Spelling
 
 We write in American English, using [Merriam Webster's online dictionary](https://www.merriam-webster.com/) as the standard spelling reference.
+
+### Code Blocks
+
+To add a copy button to a code block, add `{.copy}` after the language format.
+
+For example
+
+```md
+```yaml {.copy}
+tls:
+  key:      ./server.key   # Path to the TLS private key
+  cert:     ./server.cert  # Path to the TLS certificate
+  password: ""             # An optional password to decrypt the TLS private key
+```
+
+The code block *must* have a valid language type for the copy function to work.
 
 ## Shortcodes
 

--- a/content/cli/kes-identity/new.md
+++ b/content/cli/kes-identity/new.md
@@ -15,10 +15,30 @@ You cannot add identities to a stateless KES implementation with this command.
 Instead, define the identities for stateless implementations in the [config file]({{< relref "/tutorials/configuration#config-file" >}}).
 {{< /admonition >}}
 
+The output of the command resembles the following:
+
+```shell
+Your API key:
+
+   kes:v1:ABuhW1PU/dL1VL41trsQJzYYFMV5FfAcoF7NHu1U9ckk
+
+This is the only time it is shown. Keep it secret and secure!
+
+Your Identity:
+
+   5f1c9dfec3a190f8c3f07d417c223243042fdf8a1df08cfc952a57ee5dc7288e
+
+The identity is not a secret. It can be shared. Any peer
+needs this identity in order to verify your API key.
+
+The identity can be computed again via:
+
+    kes identity of kes:v1:ABuhW1PU/dL1VL41trsQJzYYFMV5FfAcoF7NHu1U9ckk
+```
+
 ## Syntax
 
 kes identity new
-             subject
              [--cert <path>]
              [--dns <domain>]
              [--encrypt]
@@ -26,14 +46,9 @@ kes identity new
              [--force, -f]
              [--ip <ip>]
              [--key <path>]
+             [<subject>]
 
 ## Parameters
-
-### `subject`
-
-_Required_
-
-The name to use for the identity.
 
 ### `--cert`
 
@@ -41,7 +56,7 @@ _Optional_
 
 Path to the public certificate for the new identity.
 
-If not specified, KES assumes the certificate is located at `./public.crt`.
+Use with the ``--key`` flag.
 
 ### `--dns`
 
@@ -85,9 +100,16 @@ Requires the `--key` and `--cert` flags.
 
 _Optional_
 
-Specify the path to the file for the private key for the new identity.
+Specify the path to the file for the private key to use for the new identity.
 
-If not specified, KES assumes the key can be found at `./private.key`.
+Use with the ``--cert`` flag.
+
+### `subject`
+
+_Optional_
+
+The name to use for the identity.
+If not specified, KES automatically generates an identity.
 
 ## Examples
 
@@ -112,5 +134,5 @@ $ kes identity new --key client1.key --cert client1.crt --encrypt Client-1
 Create an encrypted identity, `Client-365`, that expires in 1 year (8760 hours).
 
 ```sh {.copy}
-$ kes identity new --key client365.key --cert client365.crt --encrypt Client-365 --expiry 8760h
+$ kes identity new --key server.key --cert server.crt --encrypt --expiry 8760h
 ```

--- a/content/cli/kes-identity/new.md
+++ b/content/cli/kes-identity/new.md
@@ -50,13 +50,19 @@ _Optional_
 Specify a domain name to use as a subject alternate name (SAN) for the identity.
 You can repeat the flag to add multiple domain names as SANs.
 
+Requires the `--key` and `--cert` flags.
+
 ### `--encrypt`
 
 Encrypt the private key with a password.
 
+Requires the `--key` and `--cert` flags.
+
 ### `--expiry`
 
 Number of hours in `#h` format until the certificate expires.
+
+Requires the `--key` and `--cert` flags.
 
 If not specified, the certificate expires in `720h` (30 days).
 
@@ -73,6 +79,8 @@ _Optional_
 Specify an IPv4 address to use as a subject alternate name (SAN) for the identity.
 You can repeat the flag to add multiple IPs as SANs.
 
+Requires the `--key` and `--cert` flags.
+
 ### `--key`
 
 _Optional_
@@ -86,7 +94,7 @@ If not specified, KES assumes the key can be found at `./private.key`.
 Create an identity with the default expiration that uses the default path for the key and certificate locations.
 
 ```sh {.copy}
-$ kes identity new Client-1
+$ kes identity new
 ```
 
 Create an identity that uses either of two IP addresses as a subject alternate name (SAN).

--- a/content/concepts/server-api.md
+++ b/content/concepts/server-api.md
@@ -99,7 +99,7 @@ You can disable the requirement for a valid certificate when calling this endpoi
     "method"  : string
     "path"    : string
     "max_body": number   // in bytes
-    "timeout" : number   // in seconds, 0 indicates never times out
+    "timeout" : number   // in seconds, 0 indicates never times out;
   }
 ]
 ```
@@ -114,11 +114,8 @@ $ curl \
 ```
 
 #### Sample Response
-```json
-{ 
-  "version": "0.18.0"
-}
-```
+
+Request results in either a ``200 Ok`` response or an error.
 
 ### API
 

--- a/content/concepts/server-api.md
+++ b/content/concepts/server-api.md
@@ -8,9 +8,18 @@ tableOfContents: true
 
 ## API Overview
 
+By default, KES requires a valid certificate for any API call.
+Requests without a certificate fail with a TLS error.
+
+You can disable the requirement for a valid certificate when calling some endpoints in the KES [configuration file]({{< relref "tutorials/configuration.md#api-configuration" >}}).
+
+If any endpoint does not require a certificate, failed calls result in an HTTP error instead of a TLS error.
+
+
 | [**API**](#Version)                                     |                                                             |
 |:--------------------------------------------------------|:------------------------------------------------------------|
 | [`/version`](#version)                                  | Get version information.                                    |
+| [`/ready`](#ready)                                      | Return KES server readiness.                                |
 | [`/v1/api`](#api)                                       | Get a list of supported API endpoints.                      |
 | [`/v1/metrics`](#metrics)                               | Get server metrics in the Prometheus exposition format.     |
 | [`/v1/status`](#status)                                 | Get server status information.                              |
@@ -72,6 +81,45 @@ $ curl \
 }
 ```
 
+### Ready
+
+| Method   | Path                        | Content-Type       |
+|:--------:|:---------------------------:|:------------------:|
+| `GET`    | `/v1/ready`                 | `application/json` |
+
+Return the KES server readiness.
+
+You can disable the requirement for a valid certificate when calling this endpoint in the KES [configuration file]({{< relref "tutorials/configuration.md#api-configuration" >}}).
+
+#### Format
+
+```
+[
+  {
+    "method"  : string
+    "path"    : string
+    "max_body": number   // in bytes
+    "timeout" : number   // in seconds, 0 indicates never times out
+  }
+]
+```
+
+#### Sample Request
+```bash
+$ curl \
+    --key root.key \
+    --cert root.cert \
+    --request GET \
+    'https://play.min.io:7373/v1/ready'
+```
+
+#### Sample Response
+```json
+{ 
+  "version": "0.18.0"
+}
+```
+
 ### API
 
 | Method   | Path                        | Content-Type       |
@@ -79,6 +127,8 @@ $ curl \
 | `GET`    | `/v1/api`                   | `application/json` |
 
 Get a list of API endpoints supported by the server.
+
+You can disable the requirement for a valid certificate when calling this endpoint in the KES [configuration file]({{< relref "tutorials/configuration.md#api-configuration" >}}).
 
 #### Format
 
@@ -275,6 +325,9 @@ Get server metrics.
 For example, the total number of requests.
 Metrics return in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/).
 
+You can disable the requirement for a valid certificate when calling this endpoint in the KES [configuration file]({{< relref "tutorials/configuration.md#api-configuration" >}}).
+
+
 ```sh
 # TYPE kes_http_request_active gauge
 kes_http_request_active 0
@@ -370,6 +423,15 @@ kes_system_up_time 837876.75
 
 Get the current status of the KES server. 
 If the server is up, the request returns `200 OK` and a JSON document that describes status-related server information.
+The information the response returns includes the following:
+
+- Version
+- Uptime
+- Keystore status
+- Keystore latency (in ms)
+
+You can disable the requirement for a valid certificate when calling this endpoint in the KES [configuration file]({{< relref "tutorials/configuration.md#api-configuration" >}}).
+
 
 #### Format
 

--- a/content/concepts/server-api.md
+++ b/content/concepts/server-api.md
@@ -115,7 +115,13 @@ $ curl \
 
 #### Sample Response
 
-Request results in either a ``200 Ok`` response or an error.
+An authenticated request results in one of the following HTML codes:
+
+| Response              | Readiness |
+|:---------------------:|:---------:|
+| `200 Ok`              | Ready     |
+| `502 Bad Gateway`     | Not ready |
+| `504 Gateway Timeout` | Not ready |
 
 ### API
 
@@ -373,6 +379,7 @@ $ curl \
 ```
 
 #### Sample Response
+
 ```bash
 # HELP kes_http_request_active Number of active requests that are not finished, yet.
 # TYPE kes_http_request_active gauge

--- a/content/includes/server-config.md
+++ b/content/includes/server-config.md
@@ -58,12 +58,12 @@ tls:
 # The API configuration. The APIs exposed by the KES server can
 # be adjusted here. Each API is identified by its API path.
 #
-# In general, the KES server uses sane defaults for all APIs.
+# In general, the KES server uses reasonable defaults for all APIs.
 # Only customize the APIs if there is a real need.
 # 
 # Disabling authentication for an API must be carefully evaluated.
-# One example, when disabling authentication may be justified, would
-# be the liveness and readiness probes in a Kubernetes environment.
+# One example when disabling authentication may be justified could
+# be the readiness probe in a Kubernetes environment.
 #
 # When authentication is disabled, the particular API can be
 # accessed by any client that can send HTTPS requests to the

--- a/content/includes/server-config.md
+++ b/content/includes/server-config.md
@@ -1,0 +1,361 @@
+The following yaml file provides an example configuration file with notes for use.
+For the latest example file, see the [GitHub repository](https://raw.githubusercontent.com/minio/kes/master/server-config.yaml).
+
+```yaml
+# The config file version. Currently this field is optional but future
+# KES versions will require it. The only valid value is "v1". 
+version: v1
+
+# The TCP address (ip:port) for the KES server to listen on.
+address: 0.0.0.0:7373 # The pseudo address 0.0.0.0 refers to all network interfaces 
+
+admin:
+  # The admin identity identifies the public/private key pair
+  # that can perform any API operation.
+  # The admin account can be disabled by setting a value that
+  # cannot match any public key - e.g. "foobar" or "disabled".
+  identity: c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d
+
+# The TLS configuration for the KES server. A KES server
+# accepts HTTP only over TLS (HTTPS). Therefore, a TLS
+# private key and public certificate must be specified,
+# either here as part of the config file or via CLI arguments.
+tls:
+  key:      ./server.key   # Path to the TLS private key
+  cert:     ./server.cert  # Path to the TLS certificate
+  password: ""             # An optional password to decrypt the TLS private key
+  
+  # An optional path to a file or directory containing X.509 certificate(s).
+  # If set, the certificate(s) get added to the list of CA certificates for
+  # verifying the mTLS certificates sent by the KES clients.
+  #
+  # If empty, the system root CAs will be used.
+  ca:       ""        
+
+  # The TLS proxy configuration. A TLS proxy, like nginx, sits in
+  # between a KES client and the KES server and usually acts as a
+  # load balancer or common endpoint.
+  # All connections from the KES client to the TLS proxy as well
+  # the connections from the TLS proxy to the KES server must be
+  # established over TLS.
+  proxy:
+    # The identities of all TLS proxies directly connected to the
+    # KES server.
+    #
+    # Note that a TLS proxy can act as any identity (including root)
+    # since it can forward arbitrary client certificates. Client certificates
+    # aren't secret information and a malicious TLS proxy can fake any
+    # identity it has seen before. Therefore, its critical that all TLS proxy
+    # identities are secure and trusted servers.
+    identities: []
+    # The HTTP header sent by the TLS proxy to forward certain data
+    # about the client to the KES server.
+    header:
+      # The HTTP header containing the URL-escaped and PEM-encoded
+      # certificate of the kes client forwarded by the TLS proxy.
+      cert: X-Tls-Client-Cert
+
+# The API configuration. The APIs exposed by the KES server can
+# be adjusted here. Each API is identified by its API path.
+#
+# In general, the KES server uses sane defaults for all APIs.
+# Only customize the APIs if there is a real need.
+# 
+# Disabling authentication for an API must be carefully evaluated.
+# One example, when disabling authentication may be justified, would
+# be the liveness and readiness probes in a Kubernetes environment.
+#
+# When authentication is disabled, the particular API can be
+# accessed by any client that can send HTTPS requests to the
+# KES server.
+#
+# When disabling authentication for any API, the KES server will
+# change its TLS handshake behavior. By default, KES requires that
+# a client sends a client certificate during the handshake or KES
+# aborts the handshake. This means that a client can only send an
+# HTTP request to KES when it provides a certificate during the
+# handshake. This is no longer the case when authentication is 
+# disabled for at least one API. Clients should be able to call
+# the API even without a certificate. Hence, KES can no longer
+# require a certificate during the TLS handshake but instead has
+# to check the certificate when executing the API handler. 
+# 
+# Now, these two behaviors have slightly different semantics:
+# By default, KES does not accept connections from clients without
+# a TLS certificate. When disabling authentication for one API, KES
+# has to accept connections from any client for all APIs. However,
+# the API handlers that still require authentication will reject
+# requests from clients without a certificate. Instead of a TLS
+# error these clients will receive an HTTP error.
+#
+# Currently, authentication can only be disabled for the
+# following APIs:
+#   - /v1/ready
+#   - /v1/status
+#   - /v1/metrics
+#   - /v1/api
+#
+api:
+  /v1/ready:
+    skip_auth: false
+    timeout:   15s
+    
+# The (pre-defined) policy definitions.
+#
+# A policy must have an unique name (e.g my-app) and specifies which
+# server APIs can be accessed. An API path pattern is a glob pattern
+# of the following form:
+#   <API-version>/<API>/<operation>/[<argument-0>/<argument-1>/...]>
+#
+# Each KES server API has an unique path - e.g. /v1/key/create/<key-name>.
+# A client request is allowed if and only if no deny pattern AND at least one
+# allow pattern matches the request URL path.
+#
+# A policy has zero (by default) or more assigned identities. However,
+# an identity can never be assigned to more than one policy at the same
+# time. So, one policy has N assigned identities but one identity is
+# assigned to at most one policy.
+#
+# In general, each user/application should only have the minimal
+# set of policy permissions to accomplish whatever it needs to do.
+# Therefore, it is recommended to define policies based on workflows
+# and then assign them to the identities.
+
+# The following policy section shows some example policy definitions.
+# Please remove/adjust to your needs.
+policy:
+  my-app:
+    allow:
+    - /v1/key/create/my-app*
+    - /v1/key/generate/my-app*
+    - /v1/key/decrypt/my-app*
+    deny:
+    - /v1/key/generate/my-app-internal*
+    - /v1/key/decrypt/my-app-internal*
+    identities:
+    - df7281ca3fed4ef7d06297eb7cb9d590a4edc863b4425f4762bb2afaebfd3258
+    - c0ecd5962eaf937422268b80a93dde4786dc9783fb2480ddea0f3e5fe471a731
+
+  my-app-ops:
+    allow:
+    - /v1/key/delete/my-app*
+    - /v1/policy/show/my-app
+    - /v1/identity/assign/my-app/*
+    identities:
+    - 7ec8095a5308a535b72b35c7ccd4ce1d7c14af713acd22e2935a9d6e4fe18127
+
+cache:
+  # Cache expiry specifies when cache entries expire.
+  expiry:
+    # Period after which any cache entries are discarded.
+    # It determines how often the KES server has to fetch
+    # a secret key from the KMS.
+    #
+    # If not set, KES will default to an expiry of 5 minutes.
+    any: 5m0s
+    # Period after which all unused cache entries are discarded.
+    # It determines how often "not frequently" used secret keys
+    # must be fetched from the KMS.
+    #
+    # If not set, KES will default to an expiry of 30 seconds.
+    unused: 20s
+    # Period after which any cache entries in the offline cache
+    # are discarded.
+    # It determines how long the KES server can serve stateless
+    # requests when the KMS key store has become unavailable -
+    # e.g. due to a network outage.
+    #
+    # If not set, KES will disable the offline cache.
+    #
+    # Offline caching should only be enabled when trying to
+    # reduce the impact of the KMS key store being unavailable.
+    offline: 0s
+
+# The console logging configuration. In general, the KES server
+# distinguishes between (operational) errors and audit events.
+# By default, the KES server logs error events to STDERR but
+# does not log audit log events to STDOUT.
+#
+# The following log configuration only affects logging to console.
+log:
+  # Enable/Disable logging error events to STDERR. Valid values
+  # are "on" or "off". If not set the default is "on". If no error
+  # events should be logged to STDERR it has to be set explicitly
+  # to: "off".
+  error: on
+
+  # Enable/Disable logging audit events to STDOUT. Valid values
+  # are "on" and "off". If not set the default is "off".
+  # Logging audit events to STDOUT may flood your console since
+  # there will be one audit log event per request-response pair.
+  #
+  # For tracing/monitoring audit logs take a look at the
+  # /v1/log/audit/trace API.
+  #
+  # Each audit event is a JSON object representing a request-response
+  # pair that contains the time, client identity, the API path, HTTP
+  # response status code etc.
+  # {
+  #   "time": "2006-01-02T15:04:05Z07:00",
+  #   "request": {
+  #     "ip":       "87.149.99.199",
+  #     "enclave":  "default",
+  #     "path":     "/v1/key/create/my-app-key",
+  #     "identity": "4067503933d4a78358f908a2df7ec14e554c612acf8a9d1aa29b7da4aa018ec9",
+  #   },
+  #   "response": {
+  #     "status": 200
+  #   }
+  # }
+  # The server will write such an audit log entry for every HTTP
+  # request-response pair - including invalid requests.
+  audit: off
+
+# In the keys section, pre-defined keys can be specified. The KES
+# server will try to create the listed keys before startup.
+keys:
+  - name: some-key-name 
+  - name: another-key-name
+
+# The keystore section specifies which KMS - or in general key store - is
+# used to store and fetch encryption keys.
+# A KES server can only use one KMS / key store at the same time.
+# If no store is explicitly specified the server will use store
+# keys in-memory. In this case all keys are lost when the KES server
+# restarts.
+keystore:
+  # Configuration for storing keys on the filesystem.
+  # The path must be path to a directory. If it doesn't
+  # exist then the KES server will create the directory.
+  #
+  # The main purpose of the fs configuration is testing
+  # and development. It should not be used for production.
+  fs:
+    path: "" # Path to directory. Keys will be stored as files.
+
+  # Configuration for storing keys on a KES server.
+  kes:
+    endpoint: 
+    - ""           # The endpoint (or list of endpoints) to the KES server(s)
+    enclave: ""    # An optional enclave name. If empty, the default enclave will be used
+    tls:           # The KES mTLS authentication credentials - i.e. client certificate.
+      cert: ""     # Path to the TLS client certificate for mTLS authentication
+      key: ""      # Path to the TLS client private key for mTLS authentication
+      ca: ""       # Path to one or multiple PEM root CA certificates
+    
+  # Configuration for storing keys via a KES KeyStore plugin or at
+  # a KeyStore that exposes an API compatible to the KES KeyStore
+  # plugin specification: https://github.com/minio/kes/blob/master/internal/generic/spec-v1.md
+  generic:
+    endpoint: "" # The plugin endpoint - e.g. https://127.0.0.1:7001
+    tls:         # The KES client TLS configuration for mTLS authentication and certificate verification.
+      key: ""    # Path to the TLS client private key for mTLS authentication
+      cert: ""   # Path to the TLS client certificate for mTLS authentication
+      ca: ""     # Path to one or multiple PEM root CA certificates
+
+  # Hashicorp Vault configuration. The KES server will store/fetch
+  # secret keys at/from Vault's key-value backend.
+  #
+  # For more information take a look at:
+  # https://www.vaultproject.io/api/secret/kv/kv-v1.html
+  vault:
+    endpoint: ""  # The Vault endpoint - e.g. https://127.0.0.1:8200
+    engine: ""    # The path of the K/V engine - e.g. secrets. If empty, defaults to: kv. (Vault default)
+    version: ""   # The K/V engine version - either "v1" or "v2". The "v1" engine is recommended.
+    namespace: "" # An optional Vault namespace. See: https://www.vaultproject.io/docs/enterprise/namespaces/index.html
+    prefix: ""    # An optional K/V prefix. The server will store keys under this prefix.
+    approle:    # AppRole credentials. See: https://www.vaultproject.io/docs/auth/approle.html
+      engine: ""  # The path of the AppRole engine - e.g. authenticate. If empty, defaults to: approle. (Vault default)
+      id: ""      # Your AppRole Role ID
+      secret: ""  # Your AppRole Secret ID
+      retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
+    kubernetes: # Kubernetes credentials. See: https://www.vaultproject.io/docs/auth/kubernetes
+      engine: ""  # The path of the Kubernetes engine e.g. authenticate. If empty, defaults to: kubernetes. (Vault default)
+      role: ""    # The Kubernetes JWT role
+      jwt:  ""    # Either the JWT provided by K8S or a path to a K8S secret containing the JWT.
+      retry: 15s  # Duration until the server tries to re-authenticate after connection loss.
+    tls:        # The Vault client TLS configuration for mTLS authentication and certificate verification
+      key: ""     # Path to the TLS client private key for mTLS authentication to Vault
+      cert: ""    # Path to the TLS client certificate for mTLS authentication to Vault
+      ca: ""      # Path to one or multiple PEM root CA certificates
+    status:     # Vault status configuration. The server will periodically reach out to Vault to check its status.
+      ping: 10s   # Duration until the server checks Vault's status again.
+
+  fortanix:
+    # The Fortanix SDKMS key store. The server will store secret keys at the Fortanix SDKMS.
+    # See: https://www.fortanix.com/products/data-security-manager/key-management-service
+    sdkms: 
+      endpoint: ""   # The Fortanix SDKMS endpoint - for example: https://sdkms.fortanix.com
+      group_id: ""   # An optional group ID newly created keys will be placed at. For example: ce08d547-2a82-411e-ae2d-83655a4b7617 
+                     # If empty, the applications default group is used. 
+      credentials:   # The Fortanix SDKMS access credentials
+        key: ""      # The application's API key - for example: NWMyMWZlNzktZDRmZS00NDFhLWFjMzMtNjZmY2U0Y2ViMThhOnJWQlh0M1lZaDcxZC1NNnh4OGV2MWNQSDVVSEt1eXEyaURqMHRrRU1pZDg=
+      tls:           # The KeySecure client TLS configuration
+        ca: ""       # Path to one or multiple PEM-encoded CA certificates for verifying the Fortanix SDKMS TLS certificate. 
+  aws:
+    # The AWS SecretsManager key store. The server will store
+    # secret keys at the AWS SecretsManager encrypted with
+    # AWS-KMS. See: https://aws.amazon.com/secrets-manager
+    secretsmanager:
+      endpoint: ""   # The AWS SecretsManager endpoint      - e.g.: secretsmanager.us-east-2.amazonaws.com
+      region: ""     # The AWS region of the SecretsManager - e.g.: us-east-2
+      kmskey: ""     # The AWS-KMS key ID used to en/decrypt secrets at the SecretsManager. By default (if not set) the default AWS-KMS key will be used.
+      credentials:   # The AWS credentials for accessing secrets at the AWS SecretsManager.
+        accesskey: ""  # Your AWS Access Key
+        secretkey: ""  # Your AWS Secret Key
+        token: ""      # Your AWS session token (usually optional)
+
+  gemalto:
+    # The Gemalto KeySecure key store. The server will store
+    # keys as secrets on the KeySecure instance.
+    keysecure:
+      endpoint: ""    # The KeySecure endpoint - e.g. https://127.0.0.1
+      credentials:    # The authentication to access the KeySecure instance.
+        token: ""     # The refresh token to obtain new short-lived authentication tokens.
+        domain: ""    # The KeySecure domain for which the refresh token is valid. If empty, defaults to the root domain.
+        retry: 15s    # The time the KES server waits before it tries to re-authenticate after connection loss.
+      tls:            # The KeySecure client TLS configuration
+        ca: ""        # Path to one or multiple PEM-encoded CA certificates for verifying the KeySecure TLS certificate.
+
+  gcp:
+    # The Google Cloud Platform secret manager.
+    # For more information take a look at:
+    # https://cloud.google.com/secret-manager
+    secretmanager:
+      # The project ID is a unique, user-assigned ID that can be used by Google APIs.
+      # The project ID must be a unique string of 6 to 30 lowercase letters, digits, or hyphens.
+      # It must start with a letter, and cannot have a trailing hyphen.
+      # See: https://cloud.google.com/resource-manager/docs/creating-managing-projects#before_you_begin
+      project_id: ""
+      # An optional GCP SecretManager endpoint. If not set, defaults to: secretmanager.googleapis.com:443
+      endpoint: ""
+      # An optional list of GCP OAuth2 scopes. For a list of GCP scopes refer to: https://developers.google.com/identity/protocols/oauth2/scopes
+      # If not set, the GCP default scopes are used.
+      scopes: 
+      - ""
+      # The credentials for your GCP service account. If running inside GCP (app engine) the credentials
+      # can be empty and will be fetched from the app engine environment automatically.
+      credentials:
+        client_email:   "" # The service account email                          - e.g. <account>@<project-ID>.iam.gserviceaccount.com
+        client_id:      "" # The service account client ID                      - e.g. 113491952745362495489"
+        private_key_id: "" # The service account private key                    - e.g. 381514ebd3cf45a64ca8adc561f0ce28fca5ec06
+        private_key:    "" # The raw encoded private key of the service account - e.g "-----BEGIN PRIVATE KEY-----\n ... \n-----END PRIVATE KEY-----\n
+
+  azure:
+    # The Azure KeyVault configuration.
+    # For more information take a look at:
+    # https://azure.microsoft.com/services/key-vault
+    keyvault:
+      endpoint: ""      # The KeyVault endpoint - e.g. https://my-instance.vault.azure.net
+      # Azure client credentials used to
+      # authenticate to Azure KeyVault.
+      credentials:
+        tenant_id: ""      # The ID of the tenant the client belongs to - i.e. a UUID.
+        client_id: ""      # The ID of the client - i.e. a UUID.
+        client_secret: ""  # The value of the client secret.
+      # Azure managed identity used to
+      # authenticate to Azure KeyVault
+      # with Azure managed credentials.
+      managed_identity:
+        client_id: ""      # The Azure managed identity of the client - i.e. a UUID.
+```

--- a/content/tutorials/configuration.md
+++ b/content/tutorials/configuration.md
@@ -121,7 +121,7 @@ You can change this behavior for specific API endpoints to allow requests to the
 
 {{< admonition type="caution" >}}
 The default behavior of the KES API endpoints should be suitable for most situations.
-Only customize endpoints for specific need.
+Only customize endpoints for a specific need.
 {{< /admonition >}}
 
 When you disable authentication for at least one endpoint, KES no longer requires a certificate for a client to call _any_ API endpoint.

--- a/content/tutorials/configuration.md
+++ b/content/tutorials/configuration.md
@@ -120,14 +120,14 @@ By default, KES requires a valid TLS certificate for all API calls.
 You can change this behavior for specific API endpoints to allow requests to the endpoints without a certificate.
 
 {{< admonition type="caution" >}}
-The default behavior of the KES API endpoints should suffice in most every situation.
-Only customize endpoints for specific need
+The default behavior of the KES API endpoints should be suitable for most situations.
+Only customize endpoints for specific need.
 {{< /admonition >}}
 
 When you disable authentication for at least one endpoint, KES no longer requires a certificate for a client to call _any_ API endpoint.
-However, the request must still include a certificate for KES to successfully process a call to an API endpoint that does require authentication.
+However, the request must still include a certificate for KES to successfully process a call to any API endpoint that requires authentication.
 
-This change means that on KES servers with at least one endpoint configured to disable authentication, clients no receive a TLS error on failure, but an HTTP error instead.
+This change means that on KES servers with at least one endpoint configured to disable authentication, clients do not receive a TLS error on failure, but an HTTP error instead.
 
 You can disable authentication for the following API endpoints:
 
@@ -324,9 +324,9 @@ policy:
     - ${MY_APP_IDENTITY}
 ```
 
-{{< admonition title="Admonition title" type="note" >}}
-The server does not fail if an environment variable is not present or not a "valid" identity. 
+{{< admonition type="note" >}}
 You must set all expected environment variables before starting the server.
+The server starts even if an environment variable is not present or does not contain a "valid" identity. 
 {{< /admonition >}}
 
 
@@ -360,7 +360,7 @@ keystore:
     path: ./keys # The key store directory. Keys will be created inside ./keys/
 ```
 
-For production setups, only secure key stores backed by a KMS such as [Hashicorp Vault](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore). 
+For production setups, use a secure key store backed by a KMS such as [Hashicorp Vault](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore). 
 
 ## Sample Configuration File
 

--- a/content/tutorials/configuration.md
+++ b/content/tutorials/configuration.md
@@ -95,9 +95,10 @@ The config file is separated into various sections:
 
  - A general server configuration section including the server address and root identity.
  - A [TLS section](#tls-configuration) to specify the server key/certificate and TLS proxy configuration.
+ - An [API section](#api-configuration) to enable or disable authentication for specific endpoints.
+ - A [policy section](#policy-configuration) to control who can perform various API operations.
  - A [cache section](#cache-configuration) to control how long the KES server caches keys in memory.
  - A [logging section](#logging-configuration) to control what log messages write to `STDOUT` and `STDERR`.
- - A [policy section](#policy-configuration) to control who can perform various API operations.
  - A [KMS / key store section](#kms-configuration) specifies where to store and fetch keys.
 
 #### TLS Configuration
@@ -112,6 +113,42 @@ tls:
 
 Optionally, also configure a TLS proxy in this section. 
 See the separate [TLS Proxy page]({{< relref "concepts/tls-proxy" >}}) for more information.
+
+#### API Configuration
+
+By default, KES requires a valid TLS certificate for all API calls.
+You can change this behavior for specific API endpoints to allow requests to the endpoints without a certificate.
+
+{{< admonition type="caution" >}}
+The default behavior of the KES API endpoints should suffice in most every situation.
+Only customize endpoints for specific need
+{{< /admonition >}}
+
+When you disable authentication for at least one endpoint, KES no longer requires a certificate for a client to call _any_ API endpoint.
+However, the request must still include a certificate for KES to successfully process a call to an API endpoint that does require authentication.
+
+This change means that on KES servers with at least one endpoint configured to disable authentication, clients no receive a TLS error on failure, but an HTTP error instead.
+
+You can disable authentication for the following API endpoints:
+
+- `/v1/ready`
+- `/v1/status`
+- `/v1/metrics`
+- `/v1/api`
+
+For example, to skip authentication for the endpoints that allow readiness probes and status checks, add the following to the configuration file:
+
+```yaml
+api:
+  /v1/ready:
+    skip_auth: true
+    timeout:   15s
+  /v1/ready:
+    skip_auth: false
+    timeout:   15s
+```
+
+See [link text]({{< relref "concepts/server-api.md" >}}) for information on the KES API.
 
 #### Cache Configuration
 
@@ -287,8 +324,11 @@ policy:
     - ${MY_APP_IDENTITY}
 ```
 
-**Note:** The server does not fail if an environment variable is not present or not a "valid" identity. 
+{{< admonition title="Admonition title" type="note" >}}
+The server does not fail if an environment variable is not present or not a "valid" identity. 
 You must set all expected environment variables before starting the server.
+{{< /admonition >}}
+
 
 #### Key Configuration
 
@@ -321,3 +361,7 @@ keystore:
 ```
 
 For production setups, only secure key stores backed by a KMS such as [Hashicorp Vault](https://github.com/minio/kes/wiki/Hashicorp-Vault-Keystore). 
+
+## Sample Configuration File
+
+{{< include "includes/server-config.md" >}}


### PR DESCRIPTION
Updates for two KES releases
    
`KES 2023-04-03T16-41-28Z`
- Adds new API section to configuration doc
- Creates a new include for the server.yaml example
- Updates the status API with additional info
    
Closes #27
    
`KES 2023-05-02T22-48-10Z`
- Updates kes identity new command
- Adds ready API endpoint
    
Closes #30

Staged:

*Note: If you click around the site with the generated links, you'll need to manually add `index.html` to the end of each URL.*

- [API Config](http://192.241.195.202:9000/staging/api-updates/tutorials/configuration/index.html#api-configuration)
- [Server](http://192.241.195.202:9000/staging/api-updates/includes/server-config/index.html)
- [Ready API](http://192.241.195.202:9000/staging/api-updates/concepts/server-api/index.html#ready)
- [Status API](http://192.241.195.202:9000/staging/api-updates/concepts/server-api/index.html#status)