### PR TITLE
Adding doc switch to toml

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/kes-docs-theme"]
 	path = themes/kes-docs-theme
-	url = git@github.com:minio/kes-docs-theme
+	url = https://github.com/minio/kes-docs-theme

--- a/config.toml
+++ b/config.toml
@@ -279,3 +279,12 @@ relativeURLs = "True"
         weight = 5
         [menu.platform.params]
             activeFill = '#0076d2'
+     [[menu.docs]]
+        name = "KES Documentation"
+        weight = 1
+        [menu.docs.params]
+            current = true
+     [[menu.docs]]
+        name = "MinIO Documentation"
+        url = "https://min.io/docs"
+        weight = 2


### PR DESCRIPTION
This updates the kes-docs-theme to the commit that includes layout changes to add a doc switch choice to select between KES docs and MinIO docs.
Also updates the config.toml to add the new menu.