### PR TITLE
Adds a page for integration with Entrust KeyControl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The KES docs use [Hugo](https://www.gohogo.io) to generate static HTML pages.
     - [Internal linking](#internal-linking)
     - [Components (Tabs, Admonitions, Cards, etc.)](#components-tabs-admonitions-cards-etc)
   - [Frontmatter](#frontmatter)
+    - [Custom Frontmatter params](#custom-frontmatter-params)
 
 ## Prerequisites
 
@@ -28,16 +29,17 @@ The KES docs use [Hugo](https://www.gohogo.io) to generate static HTML pages.
 ## Initial Setup
 
 1. Clone this repository
-2. cd to the directory
+2. cd to the directory (`cd kes-docs`)
 3. Initialize the theme directory submodule
 
    ```
    git submodule update --init --recursive
    ```
 
-   **Note:** You must have access to the remote theme repository, which is a private MinIO repository.
-
-4. Setup the theme as described in `themes/kes-docs-theme/README.md`
+4. `cd themes/kes-doc-theme`
+5. `npm install`
+6. `npm build`
+7. `cd ../../`
 
 ## Update Theme from Upstream Repository
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The KES docs use [Hugo](https://www.gohogo.io) to generate static HTML pages.
    git submodule update --init --recursive
    ```
 
-4. `cd themes/kes-doc-theme`
+4. `cd themes/kes-docs-theme`
 5. `npm install`
-6. `npm build`
+6. `npm run build`
 7. `cd ../../`
 
 ## Update Theme from Upstream Repository

--- a/content/_index.md
+++ b/content/_index.md
@@ -128,14 +128,14 @@ MinIO strongly recommends synchronizing changes to configuration files in distri
 
 ## Supported KMS Targets
 
- - [Hashicorp Vault]({{< relref "/integrations//hashicorp-vault-keystore.md" >}})
- - [Fortanix SDKMS]({{< relref "/integrations/fortanix-sdkms.md" >}})
- - [Thales CipherTrust Manager (formerly Gemalto KeySecure)]({{< relref "/integrations/thales-ciphertrust.md" >}})
  - [AWS Secrets Manager]({{< relref "/integrations/aws-secrets-manager.md" >}})
- - [Google Cloud Secret Manager]({{< relref "/integrations/google-cloud-secret-manager.md" >}})
  - [Azure KeyVault]({{< relref "/integrations/azure-keyvault.md" >}})
+ - [Entrust KeyControl]({{< relref "/integrations/entrust-keycontrol.md" >}})
+ - [Fortanix SDKMS]({{< relref "/integrations/fortanix-sdkms.md" >}})
+ - [Google Cloud Secret Manager]({{< relref "/integrations/google-cloud-secret-manager.md" >}})
+ - [Hashicorp Vault]({{< relref "/integrations//hashicorp-vault-keystore.md" >}})
  - [Local Filesystem]({{< relref "/tutorials/filesystem-keystore.md" >}})
-
+ - [Thales CipherTrust Manager (formerly Gemalto KeySecure)]({{< relref "/integrations/thales-ciphertrust.md" >}})
 
 ## External References
 ### API Documentation

--- a/content/cli/kes-enclave/create.md
+++ b/content/cli/kes-enclave/create.md
@@ -35,7 +35,7 @@ The [`subject`]({{< relref "cli/kes-identity/new.md#subject" >}}) of the identit
 
 ### `--insecure, -k`
 
-{{< include "_includes/params/insecure.md" >}}
+{{< include "_includesinsecure.md" >}}
 
 ## Examples
 

--- a/content/cli/kes-enclave/create.md
+++ b/content/cli/kes-enclave/create.md
@@ -35,7 +35,7 @@ The [`subject`]({{< relref "cli/kes-identity/new.md#subject" >}}) of the identit
 
 ### `--insecure, -k`
 
-{{< include "_includesinsecure.md" >}}
+{{< include "_includes/params/insecure.md" >}}
 
 ## Examples
 

--- a/content/cli/kes-identity/info.md
+++ b/content/cli/kes-identity/info.md
@@ -33,7 +33,7 @@ kes identity info                   \
 
 ### `--color`
 
-{{< include "_includes/params/_color.md" >}}
+{{< include "_includes/params/color.md" >}}
 
 ### `--enclave, -e`
 

--- a/content/cli/kes-key/create.md
+++ b/content/cli/kes-key/create.md
@@ -24,7 +24,7 @@ kes key create                  \
 
 ### `name`
 
-{{< include "_includes/params/_name.md" >}}
+{{< include "_includes/params/name.md" >}}
 
 You may add multiple names to a single command to generate multiple keys.
 

--- a/content/cli/kes-key/rm.md
+++ b/content/cli/kes-key/rm.md
@@ -40,7 +40,7 @@ To remove more than one key, separate each key with a space.
 
 ### `--insecure, -k`
 
-{{< include "_includes/params/include.md" >}}
+{{< include "_includes/params/insecure.md" >}}
 
 ## Examples
 

--- a/content/integrations/entrust-keycontrol.md
+++ b/content/integrations/entrust-keycontrol.md
@@ -98,7 +98,7 @@ After creating a new vault, box inside the vault, and the user access policy in 
 ### Generate KES server private key & certificate
 
 Generate a TLS private key and certificate for your KES server.
-If you already have TLS certificate you want to use for your KES server or a working KES server, you can skip this step.
+If you already have either a TLS certificate you want to use for your KES server or a working KES server, you can skip this step.
 
 The following command generates a new TLS private key (`private.key`) and a self-signed X.509 certificate (`public.crt`) issued for the IP `127.0.0.1` and DNS name `localhost`.
 

--- a/content/integrations/entrust-keycontrol.md
+++ b/content/integrations/entrust-keycontrol.md
@@ -1,0 +1,289 @@
+---
+title: Entrust KeyControl
+date: 2023-08-01
+lastmod: :git
+draft: false
+tableOfContents: true
+---
+
+[Entrust KeyControl](https://www.entrust.com/digital-security/key-management/keycontrol) is a proprietary KMS that provides a secret store that can be used by KES.
+
+```goat
+                +-----------------------------------------+
+ .----------.   |   .----------.    .------------------.  |
+| KES Client +--+--+ KES Server +--+ Entrust KeyControl | |
+ '----------'   |   '----------'    '------------------'  |
+                +-----------------------------------------+
+```
+
+## Prerequisites
+
+
+This guide assumes that you have setup an Entrust KeyControl v10.1 cluster. 
+
+For instructions to set up an Entrust KeyControl cluster, refer to the Entrust documentation:
+ - [Entrust KeyControl on AWS](https://docs.hytrust.com/DataControl/10.1/Online/Content/Books/Amazon-Web-Services/Creating-KC-Cluster-AWS/Configuring-the-First-KC-Node-AWS.html)
+ - [Entrust KeyControl on prem](https://docs.hytrust.com/DataControl/10.1/Online/Content/OLH-Files/Help-content-map-all-books.html) 
+
+## Set up Entrust KeyControl
+
+Before setting up the KES Server, complete the following sections in KeyControl to add a new Vault, a Box, and one or more Users.
+
+### Create a new Vault
+
+1. Login into your KeyControl cluster as `secroot` and create a new **PASM** Vault.
+2. Access Vault Management, then select **Create Vault**.
+3. Make the following entries:
+
+   - **Type**: PASM
+   - **Name**: minio
+   - **Description**: optional additional information for the vault, or leave blank
+   - **Admin Name**: user name to to manage the vault
+     
+     Note: This user has complete access to the Vault.
+   - **Admin Email**: Email address for the vault administrator
+     
+     Note: KeyControl sends a one-time password to this email address to access the vault.
+     You need this password in the next step.
+
+### Access the new Vault
+
+1. Access the Vault URL
+   
+   This URL should be in the email with the one-time password.
+   You can also find the URL from the Vault tab in KeyControl.
+2. Use the admin user name and the one-time password emailed to you to access the vault
+
+
+### Create a new Box
+
+KeyControl stores secrets in a box inside the vault.
+Add a box to store your secrets.
+
+1. From the KeyControl Secrets Vault screen, select **Manage** then **Manage Boxes**
+2. Select **Create** to add a new Box
+  
+   or
+
+   Select **Add a Box Now** from the Manage Boxes page
+4. Make the following entries ont he **About** page
+   
+   - **Name**: A descriptive name for the box, such as the MinIO Tenant name.
+   - **Description**: Optional additional information about the secrets in the box.
+   - **Secret Expiration**: leave blank
+5. Select **Continue**
+6. Leave the options on the **Checkout Details** page blank and click **Continue**
+   
+   {{< admonition type="important" >}}
+   Do **NOT** select **Secret Checkout Duration**.
+   {{< /admonition >}}
+
+7. Leave the options on the **Rotation Details** page blank
+   
+   {{< admonition type="important" >}}
+   Do **NOT** select **Secret Rotation Duration**.
+   {{< /admonition >}}
+
+8. Select **Create** to add the new Box
+
+### Attach the 'Vault User' role policy
+
+KeyControl uses Role-Based Access Control.
+Add a policy with the `Vault User` role and attach the policy to the user account used by KES.
+
+1. Create a new Access Policy
+2. Make the following entries on the **About** page:
+
+   - **Name**: KES Service
+   - **Description**: Optional longer description for the policy
+   - **Role**: Vault User Role
+   - **Users**: The KeyControl account KES uses to access keys.
+3. Select **Continue**
+4. Make the following entries on the **Resources** page:
+
+   - **Box**: Select the box you added in the previous step from the dropdown
+   - **Secrets**: All Secrets
+5. Select **Add** to create the policy and attach it to the selected user
+
+
+## KES Server Setup
+
+After creating a new vault, box inside the vault, and the user access policy in KeyControl, you can set up the KES server.
+
+### Generate KES server private key & certificate
+
+
+First, we need to generate a TLS private key and certificate for our KES server.
+If you already have TLS certificate you want to use for your KES server you can
+skip this step.
+
+The following command generates a new TLS private key (`private.key`) and a self-signed X.509 certificate (`public.crt`) issued for the IP `127.0.0.1` and DNS name `localhost`.
+
+```sh {.copy}
+kes identity new --key private.key --cert public.crt --ip "127.0.0.1" --dns localhost
+```
+
+The output resembles the following:
+
+```sh
+Your API key:
+
+   kes:v1:APvbt/zbiewXNB+EwciOT+I21peq0odFYCwkJX8mMCxM
+
+This is the only time it is shown. Keep it secret and secure!
+
+Your Identity:
+
+   1d1f89ad528a3bbb8fd64252d443c993f5a4d679b074d5bad49785e02ec38199
+
+The identity is not a secret. It can be shared. Any peer
+needs this identity in order to verify your API key.
+
+The generated TLS private key is stored at: private.key
+The generated TLS certificate is stored at: public.crt
+
+The identity can be computed again via:
+
+    kes identity of kes:v1:APvbt/zbiewXNB+EwciOT+I21peq0odFYCwkJX8mMCxM
+    kes identity of public.crt
+```
+ 
+### Generate a new API key
+
+The client application needs some credentials to access the KES server. 
+The following command generates a new API key.
+
+```sh {.copy}
+kes identity new
+```
+
+The resulting key resembles:
+
+```sh
+Your API key:
+
+   kes:v1:AOlQZJRMYZeOioGk0ubYBMSFt1w6Hh1QZl3zG4PQxK/g
+
+This is the only time it is shown. Keep it secret and secure!
+
+Your Identity:
+
+   eb559798a2fbcc3efbf036bed11108116e63f293324abdfe7574249ef5e56b36
+
+The identity is not a secret. It can be shared. Any peer
+needs this identity in order to verify your API key.
+
+The identity can be computed again via:
+
+    kes identity of kes:v1:AOlQZJRMYZeOioGk0ubYBMSFt1w6Hh1QZl3zG4PQxK/g
+```
+
+### Configure the KES Server
+
+Create the KES server configuration file: `config.yml`.
+Make sure that the identity in the policy section matches your API key identity.
+
+```yaml {.copy}
+address: 0.0.0.0:7373 # Listen on all network interfaces on port 7373
+
+admin:
+  identity: disabled  # We disable the admin identity since we don't need it in this guide 
+   
+tls:
+  key: private.key    # The KES server TLS private key
+  cert: public.crt    # The KES server TLS certificate
+   
+policy:
+  my-app: 
+    allow:
+    - /v1/key/create/my-key*
+    - /v1/key/generate/my-key*
+    - /v1/key/decrypt/my-key*
+    identities:
+    - eb559798a2fbcc3efbf036bed11108116e63f293324abdfe7574249ef5e56b36 # Use the identity of your API key
+   
+keystore:
+     entrust:
+       keycontrol:
+         endpoint: "https://keycontrol.my-org.com"    # Use your KeyControl instance endpoint.
+         vault_id: ""                                 # The Vault ID - e.g: "e30497c1-bff7-4e81-beb7-fb35c4b7410c".
+         box_id:   ""                                 # The Box name or ID - e.g: "tenant-1".
+         credentials:
+           username: ""                               # KeyControl username - e.g: "kes-tenant-1@my-org.com".
+           password: ""                               # Password of KeyControl user
+```
+
+### Start the KES Server
+
+Use the yaml file you created to start a KES server instance.
+
+```sh {.copy}
+kes server --config config.yml --auth off
+```
+
+{{< admonition title="Linux Swap Protection" type="tip" >}}
+
+In Linux environments, KES can use the [`mlock`](http://man7.org/linux/man-pages/man2/mlock.2.html) syscall to prevent the OS from writing in-memory data to disk (swapping). 
+This prevents leaking sensitive data.
+   
+Use the following command to allow KES to use the mlock syscall without running with `root` privileges:
+
+```sh {.copy}
+sudo setcap cap_ipc_lock=+ep $(readlink -f $(which kes))
+```
+
+Start a KES server instance with memory protection:
+   
+```sh {.copy}
+kes server --config config.yml --auth off --mlock
+```
+{{< /admonition >}}
+
+### KES CLI Access
+
+
+1. Set `KES_SERVER` Endpoint
+
+   The following environment variable specifies the server the KES CLI should talk to:
+
+   ```sh {.copy}
+   $ export KES_SERVER=https://127.0.0.1:7373
+   ```
+
+2. Define the Client Credentials
+
+   The following environment variables set the access credentials the client uses to talk to a KES server:
+   
+   ```sh {.copy}
+   $ export KES_CLIENT_CERT=client.crt
+   ```
+
+   ```sh {.copy}
+   $ export KES_CLIENT_KEY=client.key
+   ```
+
+3. Test the Configuration
+   
+   Perform any API operation allowed by the policy we assigned above. 
+   
+   For example, create a key:
+
+   ```sh {.copy}
+   $ kes key create my-key-1
+   ```
+   
+   Use the key to generate a new data encryption key:
+
+   ```sh
+   $ kes key dek my-key-1
+   {
+     plaintext : UGgcVBgyQYwxKzve7UJNV5x8aTiPJFoR+s828reNjh0=
+     ciphertext: eyJhZWFkIjoiQUVTLTI1Ni1HQ00tSE1BQy1TSEEtMjU2IiwiaWQiOiIxMTc1ZjJjNDMyMjNjNjNmNjY1MDk5ZDExNmU3Yzc4NCIsIml2IjoiVHBtbHpWTDh5a2t4VVREV1RSTU5Tdz09Iiwibm9uY2UiOiJkeGl0R3A3bFB6S21rTE5HIiwiYnl0ZXMiOiJaaWdobEZrTUFuVVBWSG0wZDhSYUNBY3pnRWRsQzJqWFhCK1YxaWl2MXdnYjhBRytuTWx0Y3BGK0RtV1VoNkZaIn0=
+   }
+   ```
+
+## References
+
+ - [Server API Doc]({{< relref "/concepts/server-api" >}})
+ - [Go SDK Doc](https://pkg.go.dev/github.com/minio/kes)
+ - [Entrust KeyControl Documentation](https://docs.hytrust.com/DataControl/10.1/Online/Content/OLH-Files/Help-content-map-all-books.html)

--- a/content/integrations/entrust-keycontrol.md
+++ b/content/integrations/entrust-keycontrol.md
@@ -6,7 +6,7 @@ draft: false
 tableOfContents: true
 ---
 
-[Entrust KeyControl](https://www.entrust.com/digital-security/key-management/keycontrol) is a proprietary KMS that provides a secret store that can be used by KES.
+[Entrust KeyControl](https://www.entrust.com/digital-security/key-management/keycontrol) is a proprietary KMS which KES supports using for storing secrets.
 
 ```goat
                 +-----------------------------------------+
@@ -18,12 +18,13 @@ tableOfContents: true
 
 ## Prerequisites
 
-
-This guide assumes that you have setup an Entrust KeyControl v10.1 cluster. 
+This procedure was written and tested against Entrust KeyControl v10.1. 
+The provided instructions may work against other KeyControl versions.
+This procedure assumes you have prior experience with Entrust products and have followed their documentation, best practices, and other published materials in deploying the KeyControl service.
 
 For instructions to set up an Entrust KeyControl cluster, refer to the Entrust documentation:
  - [Entrust KeyControl on AWS](https://docs.hytrust.com/DataControl/10.1/Online/Content/Books/Amazon-Web-Services/Creating-KC-Cluster-AWS/Configuring-the-First-KC-Node-AWS.html)
- - [Entrust KeyControl on prem](https://docs.hytrust.com/DataControl/10.1/Online/Content/OLH-Files/Help-content-map-all-books.html) 
+ - [Entrust KeyControl on-premises](https://docs.hytrust.com/DataControl/10.1/Online/Content/OLH-Files/Help-content-map-all-books.html) 
 
 ## Set up Entrust KeyControl
 
@@ -31,14 +32,14 @@ Before setting up the KES Server, complete the following sections in KeyControl 
 
 ### Create a new Vault
 
-1. Login into your KeyControl cluster as `secroot` and create a new **PASM** Vault.
-2. Access Vault Management, then select **Create Vault**.
-3. Make the following entries:
+Log in to your KeyControl cluster with a user that has root-level permissions (for example, `secroot`) and create a new **PASM** vault.
 
-   - **Type**: PASM
-   - **Name**: minio
-   - **Description**: optional additional information for the vault, or leave blank
-   - **Admin Name**: user name to to manage the vault
+Make entries similar to the following:
+
+   - **Type**: `PASM`
+   - **Name**: `minio`
+   - **Description**: Optional additional information for the vault, or leave blank.
+   - **Admin Name**: User name to to manage the vault.
      
      Note: This user has complete access to the Vault.
    - **Admin Email**: Email address for the vault administrator
@@ -46,64 +47,48 @@ Before setting up the KES Server, complete the following sections in KeyControl 
      Note: KeyControl sends a one-time password to this email address to access the vault.
      You need this password in the next step.
 
+Make other required entries as per KeyControl or your own guidelines.
+You can set the Name and Description to be more specific to your MinIO deployment or according to your own guidelines.
+
 ### Access the new Vault
 
-1. Access the Vault URL
+1. Access the Vault URL.
    
    This URL should be in the email with the one-time password.
    You can also find the URL from the Vault tab in KeyControl.
-2. Use the admin user name and the one-time password emailed to you to access the vault
+2. Use the admin user name and the one-time password sent by email to access the Vault.
 
 
 ### Create a new Box
 
-KeyControl stores secrets in a box inside the vault.
-Add a box to store your secrets.
+KeyControl stores secrets in a Box inside the Vault.
+Add a Box to store your secrets.
 
-1. From the KeyControl Secrets Vault screen, select **Manage** then **Manage Boxes**
-2. Select **Create** to add a new Box
-  
-   or
-
-   Select **Add a Box Now** from the Manage Boxes page
-4. Make the following entries ont he **About** page
+Follow the prompts and make entries similar to the following:
    
    - **Name**: A descriptive name for the box, such as the MinIO Tenant name.
    - **Description**: Optional additional information about the secrets in the box.
-   - **Secret Expiration**: leave blank
-5. Select **Continue**
-6. Leave the options on the **Checkout Details** page blank and click **Continue**
-   
-   {{< admonition type="important" >}}
-   Do **NOT** select **Secret Checkout Duration**.
-   {{< /admonition >}}
+   - **Secret Expiration**: leave blank.
+   - **Secret Checkout Duration**: leave blank.
+   - **Secret Rotation Duration**: leave blank.
 
-7. Leave the options on the **Rotation Details** page blank
-   
-   {{< admonition type="important" >}}
-   Do **NOT** select **Secret Rotation Duration**.
-   {{< /admonition >}}
-
-8. Select **Create** to add the new Box
+Make other required entries as per KeyControl or your own guidelines.
 
 ### Attach the 'Vault User' role policy
 
 KeyControl uses Role-Based Access Control.
 Add a policy with the `Vault User` role and attach the policy to the user account used by KES.
 
-1. Create a new Access Policy
-2. Make the following entries on the **About** page:
+Follow the prompts and make entries similar to the following:
 
-   - **Name**: KES Service
-   - **Description**: Optional longer description for the policy
-   - **Role**: Vault User Role
+   - **Name**: KES Service.
+   - **Description**: Optional longer description for the policy.
+   - **Role**: Vault User Role.
    - **Users**: The KeyControl account KES uses to access keys.
-3. Select **Continue**
-4. Make the following entries on the **Resources** page:
+   - **Box**: Select the box you added in the previous step from the dropdown.
+   - **Secrets**: All Secrets.
 
-   - **Box**: Select the box you added in the previous step from the dropdown
-   - **Secrets**: All Secrets
-5. Select **Add** to create the policy and attach it to the selected user
+Make other required entries as per KeyControl or your own guidelines.
 
 
 ## KES Server Setup
@@ -112,10 +97,8 @@ After creating a new vault, box inside the vault, and the user access policy in 
 
 ### Generate KES server private key & certificate
 
-
-First, we need to generate a TLS private key and certificate for our KES server.
-If you already have TLS certificate you want to use for your KES server you can
-skip this step.
+Generate a TLS private key and certificate for your KES server.
+If you already have TLS certificate you want to use for your KES server or a working KES server, you can skip this step.
 
 The following command generates a new TLS private key (`private.key`) and a self-signed X.509 certificate (`public.crt`) issued for the IP `127.0.0.1` and DNS name `localhost`.
 
@@ -150,7 +133,7 @@ The identity can be computed again via:
  
 ### Generate a new API key
 
-The client application needs some credentials to access the KES server. 
+The client application requires credentials in order to access the KES server. 
 The following command generates a new API key.
 
 ```sh {.copy}
@@ -215,7 +198,7 @@ keystore:
 
 ### Start the KES Server
 
-Use the yaml file you created to start a KES server instance.
+Use the YAML file you created to start a KES server instance.
 
 ```sh {.copy}
 kes server --config config.yml --auth off
@@ -242,7 +225,7 @@ kes server --config config.yml --auth off --mlock
 ### KES CLI Access
 
 
-1. Set `KES_SERVER` Endpoint
+1. Set the `KES_SERVER` Endpoint.
 
    The following environment variable specifies the server the KES CLI should talk to:
 
@@ -250,7 +233,7 @@ kes server --config config.yml --auth off --mlock
    $ export KES_SERVER=https://127.0.0.1:7373
    ```
 
-2. Define the Client Credentials
+2. Define the Client Credentials.
 
    The following environment variables set the access credentials the client uses to talk to a KES server:
    
@@ -262,9 +245,9 @@ kes server --config config.yml --auth off --mlock
    $ export KES_CLIENT_KEY=client.key
    ```
 
-3. Test the Configuration
+3. Test the Configuration.
    
-   Perform any API operation allowed by the policy we assigned above. 
+   Perform any API operation allowed by the policy defined in the KES server configuration file. 
    
    For example, create a key:
 


### PR DESCRIPTION
Closes #35.

To build locally, follow the steps in the branch's [README](https://github.com/minio/kes-docs/tree/keycontrol#prerequisites).

- You'll need to have Node 16.9.x or later installed, plus Hugo for your OS.
- If this is your first time to work with the KES Hugo docs, complete the Initial Setup steps in the README.
- To serve locally, use `hugo server`, then go to`https://localhost:1313` in your browser.