### PR TITLE
Adding link for enterprise docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -307,4 +307,4 @@ relativeURLs = "True"
      [[menu.docs]]
         name = "DirectPV Documentation"
         url = "https://min.io/docs/directpv"
-        weight = 3
+        weight = 4

--- a/config.toml
+++ b/config.toml
@@ -301,6 +301,10 @@ relativeURLs = "True"
         url = "https://min.io/docs/minio/kubernetes/upstream/index.html"
         weight = 2
      [[menu.docs]]
+        name = "MinIO Enterprise Object Store Documentation"
+        url = "https://min.io/docs/enterprise"
+        weight = 3
+     [[menu.docs]]
         name = "DirectPV Documentation"
         url = "https://min.io/docs/directpv"
         weight = 3


### PR DESCRIPTION
Adds a link to the doc switcher for the Enterprise docs.
Also, updates the theme to address the menu width for the long name.