### PR TITLE
Updates for KES release 2024-06-17T15-47-05Z

### DIFF
--- a/content/cli/deprecated/_index.md
+++ b/content/cli/deprecated/_index.md
@@ -1,0 +1,19 @@
+---
+title: Deprecated commands
+date: 2024-07-15
+lastmod: :git
+draft: false
+tableOfContents: true
+weight: 1000
+---
+
+The following commands have been deprecated.
+Replacement commands are listed, where applicable.
+
+## Deprecated
+
+|Subcommands                                                   |Description                                    |
+|:-------------------------------------------------------------|:----------------------------------------------|
+|[`identity ls`]({{< relref "/cli/deprecated/identity-ls" >}}) | Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |
+|[`key ls`]({{< relref "/cli/deprecated/key-ls" >}})           | Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |
+|[`policy ls`]({{< relref "/cli/deprecated/policy-ls" >}})     | Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |

--- a/content/cli/deprecated/identity-ls.md
+++ b/content/cli/deprecated/identity-ls.md
@@ -6,6 +6,11 @@ draft: false
 tableOfContents: true
 ---
 
+{{< admonition title="Command deprecated" type="important" >}}
+The `kes identity ls` command has been deprecated as of KES release `2024-06-17T15-47-05Z`.
+Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) instead.
+{{< /admonition >}}
+
 ## Overview
 
 List the identities for the KES server.

--- a/content/cli/deprecated/key-ls.md
+++ b/content/cli/deprecated/key-ls.md
@@ -6,6 +6,11 @@ draft: false
 tableOfContents: true
 ---
 
+{{< admonition title="Command deprecated" type="important" >}}
+The `kes identity ls` command has been deprecated as of KES release `2024-06-17T15-47-05Z`.
+Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) instead.
+{{< /admonition >}}
+
 ## Overview
 
 Return a list of existing cryptographic keys.

--- a/content/cli/deprecated/policy-ls.md
+++ b/content/cli/deprecated/policy-ls.md
@@ -6,6 +6,11 @@ draft: false
 tableOfContents: true
 ---
 
+{{< admonition title="Command deprecated" type="important" >}}
+The `kes identity ls` command has been deprecated as of KES release `2024-06-17T15-47-05Z`.
+Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) instead.
+{{< /admonition >}}
+
 ## Overview
 
 Outputs a list of policies on the KES server.

--- a/content/cli/kes-identity/_index.md
+++ b/content/cli/kes-identity/_index.md
@@ -8,21 +8,41 @@ tableOfContents: true
 
 ## Overview
 
-Use the `kes identity` commands to temporarily manage the identities that access the KES server.
-Use the command to display, list, create, or remove identities. 
+Use the `kes identity` commands to generate the API key of an PEM key file.
 
-All changes made by `kes identity` are lost when the KES server restarts. 
+In addition, you can use subcommands to temporarily manage the identities that access the KES server.
+Use the subcommand to display, create, or remove identities. 
+
+All changes made by `kes identity` subcommands are lost when the KES server restarts. 
 To make persistent changes to KES identities, modify the `Policies and Identities` section of the KES [configuration file]({{< relref "tutorials/configuration.md#config-file" >}}).
  Specifically, for each `policy.policyname` to modify, add/remove the identities to/from the `policy.policyname.identities` array.
 
-This page provides reference information for the `kes identity` commands.
+This page provides information for the `kes identity` commands.
+
+## Generate an API Key
+
+You can pass an Ed25519 type private key (``.PEM``) file with this command the KES returns an API key and identity for that key file.
+You can also pass the certificate (`.crt`) file or an API key and return the identity.
+
+For example, passing the `my-private-key.pem` file returns the identity and API key to use for the private key.
+
+```sh {.copy}
+kes identity my-private-key.pem
+```
+
+Passing a certificate or an API key instead of a PEM key returns only the identity for the passed value.
+
+```sh {.copy}
+kes identity my-certificate.crt
+```
+
+
 
 ## Subcommands
 
 |Subcommands                                       |Description                               |
 |:-------------------------------------------------|:-----------------------------------------|
 |[`info`]({{< relref "/cli/kes-identity/info" >}}) |Get information about a KES identity      |
-|[`ls`]({{< relref "/cli/kes-identity/ls" >}})     |List KES identities                       |
 |[`new`]({{< relref "/cli/kes-identity/new" >}})   |Create a KES identity                     |
 |[`of`]({{< relref "/cli/kes-identity/of" >}})     |Compute a KES identity from a certificate |
 
@@ -31,3 +51,9 @@ This page provides reference information for the `kes identity` commands.
 
 - [KES Policy Configuration]({{< relref "/tutorials/configuration.md#policy-configuration" >}})
 - [Conceptual information on KES]({{< relref "/concepts/_index.md" >}})
+
+## Deprecated
+
+|Subcommands                                          |Description                                    |
+|:----------------------------------------------------|:----------------------------------------------|
+|[`ls`]({{< relref "/cli/deprecated/identity-ls" >}}) | Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |

--- a/content/cli/kes-identity/new.md
+++ b/content/cli/kes-identity/new.md
@@ -38,6 +38,8 @@ The identity can be computed again via:
 
 ## Syntax
 
+
+```sh
 kes identity new
              [--cert <path>]
              [--dns <domain>]
@@ -47,6 +49,7 @@ kes identity new
              [--ip <ip>]
              [--key <path>]
              [<subject>]
+```
 
 ## Parameters
 

--- a/content/cli/kes-identity/new.md
+++ b/content/cli/kes-identity/new.md
@@ -122,7 +122,7 @@ $ kes identity new
 Create an identity that uses either of two IP addresses as a subject alternate name (SAN).
 
 ```sh {.copy}
-$ kes identity new --ip "192.168.0.182" --ip "10.0.0.92" Client-1
+$ kes identity new --ip "192.168.0.182" --ip "10.0.0.92" --key private.key --cert public.crt Client-1
 ```
 
 Create an encrypted identity that expires in the default time of 30 days.

--- a/content/cli/kes-key/_index.md
+++ b/content/cli/kes-key/_index.md
@@ -21,9 +21,14 @@ This set of pages provides reference information for the `kes key` commands.
 |[`create`]({{< relref "/cli/kes-key/create" >}})   |Create a new cryptographic key               |
 |[`import`]({{< relref "/cli/kes-key/import" >}})   |Import a cryptographic key                   |
 |[`info`]({{< relref "/cli/kes-key/info" >}})       |Output information about a cryptographic key |
-|[`ls`]({{< relref "/cli/kes-key/ls" >}})           |List cryptographic keys                      |
 |[`rm`]({{< relref "/cli/kes-key/rm" >}})           |Delete a cryptographic key                   |
 |                                                   |                                             |
 |[`encrypt`]({{< relref "/cli/kes-key/encrypt" >}}) |Encrypt a message                            |
 |[`decrypt`]({{< relref "/cli/kes-key/decrypt" >}}) |Decrypt an encrypted message                 |
 |[`dek`]({{< relref "/cli/kes-key/dek" >}})         |Generate a new data encryption key           |
+
+## Deprecated
+
+|Subcommands                                        |Description                                   |
+|:--------------------------------------------------|:---------------------------------------------|
+|[`ls`]({{< relref "/cli/deprecated/key-ls" >}})    |Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |

--- a/content/cli/kes-key/_index.md
+++ b/content/cli/kes-key/_index.md
@@ -8,7 +8,7 @@ tableOfContents: true
 
 ## Overview
 
-The :mc:`kes key` command creates, utilizes, displays, and deletes cryptographic keys (Secrets) through the MinIO Key Encryption Service (KES). 
+The `kes key` command creates, utilizes, displays, and deletes cryptographic keys (Secrets) through the MinIO Key Encryption Service (KES). 
 KES stores created secrets on the configured [Key Management System (KMS)]({{< relref "/_index.md#supported-kms-targets" >}}) target.
 
 You can also use these commands to encrypt/decrypt messages or generate new data encryption keys.

--- a/content/cli/kes-ls/_index.md
+++ b/content/cli/kes-ls/_index.md
@@ -6,8 +6,8 @@ draft: false
 tableOfContents: true
 ---
 
-{{< admonition title="Replaces deprecated commands" type="note" >}}
-The `kes ls` command replaces the following commands, which are deprecated:
+{{< admonition type="note" >}}
+The `kes ls` command replaces the following [deprecated commands]({{< relref "/cli/deprecated/_index.md" >}}):
 
 - `kes key ls`
 - `kes policy ls`
@@ -18,15 +18,17 @@ The `kes ls` command replaces the following commands, which are deprecated:
 
 Returns a list of keys, policies, or identities.
 
+If the command does not specify to list policies or identities, the command returns a list of the names of keys for the KES server.
+
+
 ## Syntax
 
 ```sh
-kes ls                         \
-    --api-key, -a <string>     \
-    --server, -s <HOST[:PORT]> \
-    --json                     \
-    --identity, -i             \
-    --policy, -p               \
+kes ls                                 \
+    --api-key, -a <string>             \
+    --server, -s <HOST[:PORT]>         \
+    --json                             \
+    [ --identity, -i | --policy, -p ]  \
     --insecure, -k
 ```
 
@@ -37,14 +39,14 @@ kes ls                         \
 *Optional*
 
 API key to use to authenticate to the KES Server.
-Defaults to the value in the `$MINIO_KES_API_KEY` environment variable.
+If not provided, the command uses the value in the [`$MINIO_KES_API_KEY`]({{< relref "/concepts/environment-variables/#minio_kes_api_key" >}}) environment variable.
 
 ### `--server, -s`
 
 *Optional*
 
 The `HOST[:PORT]` of the KES server to connect to.
-Defaults to the value in the `$MINIO_KES_SERVER` environment variable.
+If not provided, the command uses the value in the [`$MINIO_KES_SERVER`]({{< relref "/concepts/environment-variables/#minio_kes_server" >}}) environment variable.
 
 ### `--json`
 
@@ -57,12 +59,20 @@ Print the output in JSON format.
 *Optional*
 
 Print a list of identities.
+When used, the command returns only a list of the identities.
+
+This option is mutually exclusive with `--policy`.
+You can use one or the other, but not both at the same time.
 
 ### `--policy, -p`
 
 *Optional*
 
-Print a list of policies.
+Print a list of policies names.
+When used, the command returns only a list of the policies.
+
+This option is mutually exclusive with `--identity`.
+You can use one or the other, but not both at the same time.
 
 ### `--insecure, -k`
 

--- a/content/cli/kes-ls/_index.md
+++ b/content/cli/kes-ls/_index.md
@@ -1,0 +1,71 @@
+---
+title: kes ls
+date: 2023-03-03
+lastmod: :git
+draft: false
+tableOfContents: true
+---
+
+{{< admonition title="Replaces deprecated commands" type="note" >}}
+The `kes ls` command replaces the following commands, which are deprecated:
+
+- `kes key ls`
+- `kes policy ls`
+- `kes identity ls`
+{{< /admonition >}}
+
+## Overview
+
+Returns a list of keys, policies, or identities.
+
+## Syntax
+
+```sh
+kes ls                         \
+    --api-key, -a <string>     \
+    --server, -s <HOST[:PORT]> \
+    --json                     \
+    --identity, -i             \
+    --policy, -p               \
+    --insecure, -k
+```
+
+## Parameters
+
+### `--api-key, -a`
+
+*Optional*
+
+API key to use to authenticate to the KES Server.
+Defaults to the value in the `$MINIO_KES_API_KEY` environment variable.
+
+### `--server, -s`
+
+*Optional*
+
+The `HOST[:PORT]` of the KES server to connect to.
+Defaults to the value in the `$MINIO_KES_SERVER` environment variable.
+
+### `--json`
+
+*Optional*
+
+Print the output in JSON format.
+
+### `--identity, -i`
+
+*Optional*
+
+Print a list of identities.
+
+### `--policy, -p`
+
+*Optional*
+
+Print a list of policies.
+
+### `--insecure, -k`
+
+*Optional*
+
+Skip verification of the server's certificate.

--- a/content/cli/kes-policy/_index.md
+++ b/content/cli/kes-policy/_index.md
@@ -22,5 +22,11 @@ To make persistent changes to KES policies, modify the `policy` section of the K
 |[`assign`]({{< relref "/cli/kes-policy/assign" >}}) |Assign a policy to identities   |
 |[`create`]({{< relref "/cli/kes-policy/create" >}}) |Create a new policy             |
 |[`info`]({{< relref "/cli/kes-policy/info" >}})     |Get information about a policy  |
-|[`ls`]({{< relref "/cli/kes-policy/ls" >}})         |List policies                   |
 |[`show`]({{< relref "/cli/kes-policy/show" >}})     |Display a policy                |
+
+
+## Deprecated
+
+|Subcommands                                        |Description                                    |
+|:--------------------------------------------------|:----------------------------------------------|
+|[`ls`]({{< relref "/cli/deprecated/policy-ls" >}}) | Use [`kes ls`]({{< relref "/cli/kes-ls/" >}}) |

--- a/content/concepts/environment-variables.md
+++ b/content/concepts/environment-variables.md
@@ -38,7 +38,7 @@ MinIO uses this key for the following:
 ## `MINIO_KES_SERVER`
 
 The server endpoint a client uses to connect to KES.
-If not defined, the value defaults to `127.0.0.1.7373`.
+If not defined, the value defaults to `127.0.0.1:7373`.
 
 
 ## `MINIO_KES_API_KEY`

--- a/content/concepts/environment-variables.md
+++ b/content/concepts/environment-variables.md
@@ -34,3 +34,13 @@ MinIO uses this key for the following:
 - Encrypting backend data ( [IAM](https://min.io/docs/minio/linux/administration/identity-access-management.html#minio-authentication-and-identity-management), server configuration).
 - The default encryption key for Server-Side Encryption with [SSE-KMS](https://min.io/docs/minio/linux/administration/server-side-encryption/server-side-encryption-sse-kms.html#minio-encryption-sse-kms).
 - The encryption key for Server-Side Encryption with [SSE-S3](https://min.io/docs/minio/linux/administration/server-side-encryption/server-side-encryption-sse-s3.html#minio-encryption-sse-s3).
+
+## `MINIO_KES_SERVER`
+
+The server endpoint a client uses to connect to KES.
+If not defined, the value defaults to `127.0.0.1.7373`.
+
+
+## `MINIO_KES_API_KEY`
+
+The API key a client uses to authenticate to the KES server.

--- a/content/tutorials/getting-started.md
+++ b/content/tutorials/getting-started.md
@@ -202,7 +202,7 @@ This starts a KES server on `127.0.0.1:7373` and stores keys in memory.
    Start the KES server instance:
 
    ```sh {.copy}
-   kes server --config config.yml --auth off
+   kes server --config config.yml
    ```
 
 ## KES CLI Access


### PR DESCRIPTION
Updates for KES release 2024-06-17T15-47-05Z

Closes #58

Changes for deprecating several `ls` commands
Updates to the kes identity command
Fix for kes identity new example

Also fixes Getting Started tutorial command that still used the deprecated `--auth` flag.

Closes #59

Staged:

- [kes identity](http://docs-nginx.minio.training:31080/kes-docs/2024-06-17/cli/kes-identity/)
- [Deprecated commands](http://docs-nginx.minio.training:31080/kes-docs/2024-06-17/cli/deprecated/)
- [Getting started](http://docs-nginx.minio.training:31080/kes-docs/2024-06-17/tutorials/getting-started/#kes-cli-access) (Scroll up. The changed command is just above the linked heading.)